### PR TITLE
Update uncorn.rb

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -11,7 +11,7 @@ working_directory app_path
 pid "#{app_path}/tmp/pids/unicorn.pid"
 
 #ポート番号を指定
-listen 3000
+listen "#{app_path}/tmp/sockets/unicorn.sock"
 
 #エラーのログを記録するファイルを指定
 stderr_path "#{app_path}/log/unicorn.stderr.log"


### PR DESCRIPTION
# What
EC2サーバ内にwebサーバ（Nginx）を導入するため、ポート番号を仮想環境（EC2）のローカル番号3000番からwebサーバ（Nginx）用のものに変更しました

# Why
クライアント（全世界）が接続できるような仕組みとする必要があるからです
