### PR TITLE
商品購入機能の追加

### DIFF
--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -2,7 +2,7 @@
     "DOMContentLoaded", e => {
       if (document.getElementById("token_submit") != null) { //token_submitというidがnullの場合、下記コードを実行しない
         
-        Payjp.setPublicKey("pk_test_1130ceb1645b7de3074528a7"); //ここに公開鍵を直書き
+        Payjp.setPublicKey("pk_test_16c57e78f4b412c4d0a0afae"); //ここに公開鍵を直書き
         let btn = document.getElementById("token_submit"); //IDがtoken_submitの場合に取得されます
         btn.addEventListener("click", e => { //ボタンが押されたときに作動します
           e.preventDefault(); //ボタンを一旦無効化します

--- a/app/assets/stylesheets/_items.scss
+++ b/app/assets/stylesheets/_items.scss
@@ -208,6 +208,19 @@ h3 {
         &__img {
           width: 230px;
           height: 160px;
+          position: relative;
+          &--img {
+            width: 100%;
+            height: 100%;
+          }
+          &--sold {
+            position: absolute;
+            left: 0;
+            top: 0;
+            background-color: red;
+            color: white;
+            padding: 5px;
+          }
         }
         &__details {
           display: flex;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,9 @@ class ApplicationController < ActionController::Base
   end
 
   def set_card
-    @card=Card.find_by(user_id:current_user.id) #クレジットカード削除の判定に使用しているので消さないでください
+    if user_signed_in?
+      @card=Card.find_by(user_id:current_user.id) #クレジットカード削除の判定に使用しているので消さないでください
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -69,7 +69,16 @@ class ItemsController < ApplicationController
   end
 
   def pay
-    
+    @item = Item.find(params[:id])
+    @card = Card.where(user_id: current_user.id).first
+    Payjp.api_key = Rails.application.credentials.dig(:payjp, :PAYJP_SECRET_KEY)
+    charge = Payjp::Charge.create(
+      amount: @item.price,
+      customer: @card.customer_id,
+      currency: 'jpy'
+    )
+    @item.update(boughtflg_id: '2')
+    redirect_to root_path, notice: "商品の購入が完了しました"
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -53,9 +53,23 @@ class ItemsController < ApplicationController
   end
 
   def buy
+    @card = Card.where(user_id: current_user.id).first
+    if @card.blank?
+      # カード情報が登録されていない場合は登録画面へ遷移
+      redirect_to new_card_path
+    else
+      Payjp.api_key = Rails.application.credentials.dig(:payjp, :PAYJP_SECRET_KEY)
+      # 保管した顧客IDでpayjpから情報取得
+      customer = Payjp::Customer.retrieve(@card.customer_id)
+      # 保管したカードIDでpayjpから情報取得、カード情報表示のためインスタンス変数に代入
+      @default_card_information = customer.cards.retrieve(@card.card_id)
+    end
     @user = current_user
     @item = Item.find(params[:id])
-    @card = Card.where(user_id: current_user.id)
+  end
+
+  def pay
+    
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -52,6 +52,12 @@ class ItemsController < ApplicationController
     end
   end
 
+  def buy
+    @user = current_user
+    @item = Item.find(params[:id])
+    @card = Card.where(user_id: current_user.id)
+  end
+
   private
 
   def item_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :pref
   belongs_to_active_hash :birthyear
   belongs_to_active_hash :birthmonth
   belongs_to_active_hash :birthday

--- a/app/views/items/buy.html.haml
+++ b/app/views/items/buy.html.haml
@@ -1,0 +1,21 @@
+= render "shared/top-header"
+
+.item-buy-confirmation
+  .title
+    購入内容の確認
+  .image
+    = image_tag(@item.images.first, width: '50%', height: '50%', alt: '商品画像')
+  .name
+    = @item.name
+  .price
+    = @item.price
+  .address-title
+    配送先
+  .address-zipcode
+    = "〒#{@user.zipcode}"
+  .address
+    = "#{@user.pref.name}#{@user.city}#{@user.address}#{@user.buildingname}"
+  .address-name
+    = "#{@user.lastname} #{@user.firstname}"
+
+= render "shared/top-footer"

--- a/app/views/items/buy.html.haml
+++ b/app/views/items/buy.html.haml
@@ -8,14 +8,24 @@
   .name
     = @item.name
   .price
-    = @item.price
+    = "¥ " + @item.price.to_s(:delimited)
   .address-title
     配送先
   .address-zipcode
-    = "〒#{@user.zipcode}"
+    = "〒" + @user.zipcode
   .address
-    = "#{@user.pref.name}#{@user.city}#{@user.address}#{@user.buildingname}"
+    = @user.pref.name + @user.city + @user.address + @user.buildingname
   .address-name
-    = "#{@user.lastname} #{@user.firstname}"
+    = @user.lastname + " " + @user.firstname
+  .card-title
+    クレジットカード
+  .card-number
+    = "************" + @default_card_information.last4
+  .card-expiration-date
+    = "有効期限 " + @default_card_information.exp_month.to_s + " / " + @default_card_information.exp_year.to_s.slice(2,3)
+
+  .submit
+    = form_tag(action: :pay, method: :post) do
+      %button 購入する
 
 = render "shared/top-footer"

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -104,8 +104,12 @@
         - @items.reverse_each do |item| 
           = link_to item_path(item) do
             .top-main__pickup__contents__content
-              .top-main__pickup__contents__content__img          
-                = image_tag(item.images.first, width: '100%', height: '100%', alt: '商品3')
+              .top-main__pickup__contents__content__img
+                .top-main__pickup__contents__content__img--img
+                  = image_tag(item.images.first, width: '100%', height: '100%', alt: '商品3')
+                - if item.boughtflg_id == 2
+                  .top-main__pickup__contents__content__img--sold
+                    SOLD
               .top-main__pickup__contents__content__details
                 .top-main__pickup__contents__content__details__left
                   .top-main__pickup__contents__content__details__left__name
@@ -130,8 +134,12 @@
         - @items.reverse_each do |item| 
           = link_to item_path(item) do
             .top-main__pickup__contents__content
-              .top-main__pickup__contents__content__img          
-                = image_tag(item.images.first, width: '100%', height: '100%', alt: '商品3')
+              .top-main__pickup__contents__content__img
+                .top-main__pickup__contents__content__img--img
+                  = image_tag(item.images.first, width: '100%', height: '100%', alt: '商品3')
+                - if item.boughtflg_id == 2
+                  .top-main__pickup__contents__content__img--sold
+                    SOLD
               .top-main__pickup__contents__content__details
                 .top-main__pickup__contents__content__details__left
                   .top-main__pickup__contents__content__details__left__name

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -49,11 +49,13 @@
         %li.itembuy-content__table__days__name
           = @item.delivery_days.days
       %li
-        - if user_signed_in? && current_user.id == @item.user_id
+        - if user_signed_in? && current_user.id == @item.user_id && @item.boughtflg_id != 2
           = link_to item_path, method: :delete do
             削除
-        - else
+        - elsif @item.boughtflg_id != 2
           = link_to buy_item_path do
             購入
+        - else
+          売り切れました
 .footer
   = render 'shared/top-footer'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -53,7 +53,7 @@
           = link_to item_path, method: :delete do
             削除
         - else
-          = link_to '#' do
+          = link_to buy_item_path do
             購入
 .footer
   = render 'shared/top-footer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
       get 'category_children', defaults: { format: 'json' }
       get 'category_grandchildren', defaults: { format: 'json' }
     end
+    member do
+      get 'buy'
+    end
   end
   resources :users, only: [:edit, :update, :show, :destroy,] do
     member do 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     end
     member do
       get 'buy'
+      post 'pay'
     end
   end
   resources :users, only: [:edit, :update, :show, :destroy,] do


### PR DESCRIPTION
# What
商品詳細ページから遷移できる購入確認ページで購入ボタンを押すことで、商品を購入できる機能を追加。決済にはユーザに事前登録させるクレジットカードを用いる。売上情報は[Payjp公式サイト](https://pay.jp/)から確認することが可能（[実際の売上確認画面のキャプチャ](https://gyazo.com/f4547bcb583de50e073e0812089cee72)）。
以下に詳細を記述する。

## Payjpによるクレジットカード決済機能
### itemコントローラにbuyアクションを追加
詳細ページから購入確認ページ遷移時に呼ばれる。
- 遷移時に`cards`テーブルの顧客IDと紐づくカード情報をPayjpのサーバより取得。取得には`config/credentials.yml.enc`に設定したPayjpの秘密鍵を使用する。
- 購入確認ページには商品情報に加え、購入者の住所やカード情報を表示する。
  - 購入確認ページ（フロント）は未完成のため、仮で作成。
- カードが未登録の場合はカード登録画面に遷移させる。
- 商品が購入済み、またはその商品の出品者の場合はトップページに遷移させ、その旨のフラッシュメッセージを表示。
  - 詳細ページ遷移後・購入確認ページ遷移前に別ユーザが購入した場合、またはURL上直接アクセスされた場合を考慮。

※上記の修正と併せて詳細ページのリンク表示条件を以下の通り修正。
|出品者か？|商品の状態|表示文言（リンク）|
|:----:|----|----
|○|出品中|削除（destroyアクション）|
|×|出品中|購入（buyアクション）|
|-|売り切れ|売り切れました（リンク無し）|
 
### itemコントローラにpayアクションを追加
購入確認ページで購入ボタンを押した際に呼ばれる。
- 商品の価格、顧客ID、通貨をPayjpサーバに送信し、決済を行う。
- 決済成功時、`items`テーブルの`boughtflg_id`を2（売り切れ）に更新する。
- カードの有効期限切れ等で決済に失敗した場合の例外処理あり。
  - 失敗時、商品詳細ページに遷移し決済に失敗した旨のフラッシュメッセージを表示。

## トップページの商品一覧の売り切れ表示
トップページの商品一覧表示機能実装の際、売り切れ商品は表示しない、としていたが、上記機能実装に伴い表示するように改修した。
その際、売り切れていることが分かるように、売り切れた商品の画像左上に「SOLD」を表記した（[実際の画面のキャプチャ](https://gyazo.com/e1faf91ed46a14368670be5cd92ee83c)）。

# Why
フリーマーケットサイトの特性上、商品の購入機能は必須のため。